### PR TITLE
add .env file for UI, hooked up to mainnet CM for end to end test

### DIFF
--- a/js/packages/candy-machine-ui/.env
+++ b/js/packages/candy-machine-ui/.env
@@ -1,0 +1,5 @@
+REACT_APP_CANDY_MACHINE_ID=4FSoZ8euWgyT7EUWQSLks1fGWJ6TUMN633YJHrijMRW8
+
+REACT_APP_SOLANA_NETWORK=mainnet-beta
+REACT_APP_SOLANA_RPC_HOST=https://weathered-sparkling-butterfly.solana-mainnet.quiknode.pro/b4dbffeb87cc57593d67c89b2a89058534cf5611/
+SKIP_PREFLIGHT_CHECK=true


### PR DESCRIPTION
I think we just need to merge this, then vercel will pick it up and deploy to mint.swim.io
![image](https://user-images.githubusercontent.com/100168547/167517854-50fe6674-dfcf-4cc2-b23c-cc0b2ed7c3ef.png)

Candy machine uses this config
```json
{
  "price": 1e-7,
  "number": 2,
  "gatekeeper": {
    "gatekeeperNetwork": "ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6",
    "expireOnUse": true
  },
  "creators": [
    {
      "address": "ACGu2cPRsdEpDYtfrvuPu1ARS7yHie9H8ahCDupUu57p",
      "share": 100
    }
  ],
  "solTreasuryAccount": "ACGu2cPRsdEpDYtfrvuPu1ARS7yHie9H8ahCDupUu57p",
  "splTokenAccount": null,
  "splToken": null,
  "goLiveDate": "09 May 2022 23:50:13 +0000",
  "endSettings": null,
  "whitelistMintSettings": {
    "mode": "burnEveryTime",
    "mint": "4HiNRZqeRK3AFwA6r2Wij71c51fHWqCzDrLPKGX3jWED",
    "presale": false,
    "discountPrice": null
  },
  "hiddenSettings": null,
  "uploadMethod": "Bundlr",
  "retainAuthority": true,
  "isMutable": true,
  "awsS3Bucket": null,
  "symbol": "SF",
  "sellerFeeBasisPoints": 9999
}
```